### PR TITLE
SCRUM - 82 Vehicle Unbookable After Unverified Booking

### DIFF
--- a/CarRentalSystem.Server/Services/BookingService.cs
+++ b/CarRentalSystem.Server/Services/BookingService.cs
@@ -13,7 +13,7 @@ public class BookingService : IBookingService
     private readonly IPaymentService _paymentService;
     private readonly ILogger<BookingService> _logger;
 
-    private const string ConfirmationCodeChars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // No 0/O/1/I to avoid ambiguity
+    private const string ConfirmationCodeChars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
     private const int ConfirmationCodeLength = 6;
     private const string ConfirmationCodePrefix = "CRS";
 
@@ -29,7 +29,6 @@ public class BookingService : IBookingService
 
     public async Task<BookingConfirmationDto> CreateBookingAsync(CreateBookingDto dto, Guid? userId, string frontendBaseUrl)
     {
-        // Validate vehicle exists and is available for rental
         var vehicle = await _dbContext.Vehicles.FindAsync(dto.VehicleId);
         if (vehicle is null)
             throw new InvalidOperationException("Vehicle not found.");
@@ -37,21 +36,23 @@ public class BookingService : IBookingService
         if (vehicle.VehicleStatus != VehicleStatus.Active)
             throw new InvalidOperationException("Vehicle is not available for rental.");
 
-        // Normalize dates to UTC
         var startDate = DateTime.SpecifyKind(dto.StartDate.Date, DateTimeKind.Utc);
         var endDate = DateTime.SpecifyKind(dto.EndDate.Date, DateTimeKind.Utc);
 
-        // Validate dates
         if (startDate >= endDate)
             throw new InvalidOperationException("End date must be after start date.");
 
         if (startDate < DateTime.UtcNow.Date)
             throw new InvalidOperationException("Start date cannot be in the past.");
 
+        
+        var pendingExpiry = DateTime.UtcNow.AddMinutes(-10);
+
         // Check for overlapping bookings on this vehicle
         var hasOverlap = await _dbContext.Bookings.AnyAsync(b =>
             b.VehicleId == dto.VehicleId &&
             b.Status != BookingStatus.Cancelled &&
+            !(b.Status == BookingStatus.Pending && b.CreatedAt < pendingExpiry) &&
             b.StartDate < endDate &&
             b.EndDate > startDate);
 


### PR DESCRIPTION
## What changed
- Pending bookings older than 10 minutes are now excluded from the availability check
- This fixes vehicles getting stuck as unavailable after a user abandons the Stripe payment page

## Root Cause
When a user clicks "Book Now" and goes to Stripe but clicks back without paying, the booking stays as "Pending" in the database and blocks the vehicle for everyone else indefinitely.

## Fix
Added a 10 minute expiry for pending bookings. If a booking has been Pending for more than 10 minutes it is ignored when checking availability, freeing up the vehicle again.

## Files changed
- `CarRentalSystem.Server/Services/BookingService.cs`